### PR TITLE
(feat) synutils: add similarity search module and its test code

### DIFF
--- a/src/synutils/helpers.py
+++ b/src/synutils/helpers.py
@@ -9,14 +9,13 @@ LOGGER = get_logger()
 
 
 def timeit(func):
-    # TODO: change print to logger
     @wraps(func)
     def timeit_wrapper(*args, **kwargs):
         start_time = time.perf_counter()
         result = func(*args, **kwargs)
         end_time = time.perf_counter()
         total_time = end_time - start_time
-        LOGGER.info(
+        LOGGER.debug(
             f"Function {func.__name__} {kwargs.keys()} Took {total_time:.4f} seconds = {total_time/60:.1f} mins"
         )
         return result

--- a/src/synutils/path.py
+++ b/src/synutils/path.py
@@ -1,0 +1,5 @@
+from pathlib import Path
+
+ROOT_PATH = Path(__file__).parent.parent.parent
+DATA_PATH = ROOT_PATH / "data"
+TEST_PATH = ROOT_PATH / "tests"

--- a/src/synutils/similarity_search.py
+++ b/src/synutils/similarity_search.py
@@ -1,0 +1,97 @@
+import multiprocessing as mp
+from functools import partial
+from typing import Tuple
+
+import numpy as np
+import pandas as pd
+from numba import njit, prange
+from rdkit.Chem import MolFromSmiles, MolToSmiles
+
+from synutils.enum_logger import get_logger
+from synutils.featurizers import get_featurizer
+
+LOGGER = get_logger()
+FEATURIZER = get_featurizer("morgan")
+
+
+@njit
+def tanimoto(v1: np.ndarray, v2: np.ndarray) -> float:
+    """
+    Calculates tanimoto similarity for two bit vectors
+
+    Args:
+        v1 (np.ndarray): bit vector 1
+        v2 (np.ndarray): bit vector 2
+
+    Returns:
+        float: tanimoto similarity
+    """
+    return np.bitwise_and(v1, v2).sum() / np.bitwise_or(v1, v2).sum()
+
+
+@njit(parallel=True)
+def numba_tanimoto(fp: np.ndarray, fps: np.ndarray) -> np.ndarray:
+    """tanimoto similarity for numba
+
+    Args:
+        fp (np.ndarray): fingerprint
+        fps (np.ndarray): fingerprints
+
+    Returns:
+        np.ndarray: similarity
+    """
+    return_tani = np.empty(fps.shape[0], np.float32)
+    for i in prange(fps.shape[0]):
+        return_tani[i] = tanimoto(fp, fps[i, :])
+    return return_tani
+
+
+def transform_to_mol(smiles):
+    "MolFromSmiles wrapper for multiprocessing"
+    return MolFromSmiles(smiles)
+
+
+def transform_to_smiles(mol):
+    "MolToSmiles wrapper for multiprocessing"
+    return MolToSmiles(mol)
+
+
+def transform_to_fp(mol):
+    "FEATURIZER.get_feat wrapper for multiprocessing"
+    return FEATURIZER.get_feat(mol)
+
+
+def chunk_similarity_search(
+    chunk: pd.DataFrame,
+    candidates: pd.DataFrame,
+    chunk_smiles_col: str = "product",
+    cand_mol_col: str = "mol",
+    buff_cpu: int = 1,
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Similarity search of hit candidates
+
+    Args:
+        chunk (pd.DataFrame): chunk of library in pd.DataFrame
+        candidates (pd.DataFrame): hit candidates in pd.DataFrame
+        chunk_smiles_col (str, optional): library chunk's column name of smiles.
+            Defaults to "product".
+        cand_mol_col (str, optional): hit candidates' column name of mol.
+        buff_cpu (int, optional): number of cpu to use. Defaults to 1.
+
+    Returns:
+        Tuple[np.ndarray, np.ndarray]: max similarity and index of max similarity
+    """
+    # transform smiles to mol and fp
+    with mp.Pool(processes=mp.cpu_count() - buff_cpu) as pool:
+        mols = pool.map(transform_to_mol, chunk[chunk_smiles_col])
+        fps = pool.map(transform_to_fp, mols)
+    fps = np.array(fps)
+    LOGGER.info(f"There are {candidates.shape[0]} hit candidates left")
+    cand_fps = [transform_to_fp(mol) for mol in candidates[cand_mol_col]]
+    # calculate tanimoto similarity
+    with mp.Pool(processes=mp.cpu_count() - buff_cpu) as pool:
+        similarity_results = pool.map(partial(numba_tanimoto, fps=fps), cand_fps)
+    # return max similarity and index of max similarity
+    max_sims = np.array([np.max(sim) for sim in similarity_results])
+    argmax_sims = np.array([np.argmax(sim) for sim in similarity_results])
+    return max_sims, argmax_sims

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,12 @@
 from typing import List
 
-import pytest
+import pandas as pd
+from pytest import fixture
+
+from synutils.path import TEST_PATH
 
 
-@pytest.fixture
+@fixture
 def clean_smiles_list() -> List[str]:
     return [
         "O=C(O)c1ccccc1",
@@ -13,6 +16,16 @@ def clean_smiles_list() -> List[str]:
         "O=Cc1ccccc1O",
         "CCC(C=O)CC",
     ]
+
+
+@fixture
+def small_lib_df() -> pd.DataFrame:
+    return pd.read_csv(TEST_PATH / "resource" / "small_lib.csv")
+
+
+@fixture
+def hit_candidates_df() -> pd.DataFrame:
+    return pd.read_csv(TEST_PATH / "resource" / "hit_candidates.csv")
 
 
 # def temp_db(temp_path:Path):

--- a/tests/resource/hit_candidates.csv
+++ b/tests/resource/hit_candidates.csv
@@ -1,0 +1,11 @@
+smiles
+Cc1ncc(C2COCCCN2)cn1
+N#CC1(C2CC2)CCC(N2CCCC3(CCCC3)C2)CC1
+CN1CC(CNC(=O)c2c[nH]nc2C(F)(F)F)Oc2ccccc21
+Cc1cccc(F)c1C1CN(C(=O)OC(C)(C)C)CCN1
+O=C(NCc1nc(COc2ccccc2Cl)no1)c1ccc(CN2CCCCC2)c(Br)c1
+Cc1ccc2occ(C(=O)N3CCC(NC(=O)c4ccc(F)c(-c5ccc(Cl)cc5)c4)C3C)c(=O)c2c1
+Cc1cc(OC(C)(C)C(=O)N2C[C@H]3CCC[C@@H]2C3)cc(C)c1Cl
+COC1CCC(N2CCN(c3cncc(C)n3)CC2)CC1
+Cc1cc(OCc2ccc(C(=O)N[C@H]3CCC34CN(C(=O)Cc3ccc(S(N)(=O)=O)cc3)C4)cc2)cc(C)c1Cl
+COC1CCC(N2CCN(c3cncc(C)n3)CC2)CC1

--- a/tests/resource/small_lib.csv
+++ b/tests/resource/small_lib.csv
@@ -1,0 +1,11 @@
+bb1_parent_id,bb2_parent_id,product,bb1_smiles,bb2_smiles,rxn_0,rxn_1,bb1_price,bb1_anount,bb1_units,bb2_price,bb2_anount,bb2_units,inter_id,bb3_parent_id,inter_smiles,bb3_smiles,bb3_price,bb3_anount,bb3_units
+301062543,37084450.0,Cc1ccc2occ(C(=O)N3CCC(NC(=O)c4ccc(F)c(-c5ccc(Cl)cc5)c4)C3C)c(=O)c2c1,CC1C(N)CCN1C(=O)OC(C)(C)C,O=C(O)c1ccc(F)c(-c2ccc(Cl)cc2)c1,abf,abf,185.0,100.0,mg,165.0,1.0,g,68.0,905807.0,CC1NCCC1NC(=O)c1ccc(F)c(-c2ccc(Cl)cc2)c1,Cc1ccc2occ(C(=O)O)c(=O)c2c1,31.0,250.0,mg
+295586955,715254.0,COc1ccccc1Cn1cncc1C(=O)N1CC[C@H]2CN(C(=O)C3(c4ccc(F)cc4)CCCC3)C[C@H]2C1,CC(C)(C)OC(=O)N1CC[C@H]2CNC[C@H]2C1,O=C(O)C1(c2ccc(F)cc2)CCCC1,abf,abf,173.0,100.0,mg,14.0,250.0,mg,39.0,49830665.0,O=C(N1C[C@H]2CNCC[C@H]2C1)C1(c2ccc(F)cc2)CCCC1,COc1ccccc1Cn1cncc1C(=O)O,329.0,100.0,mg
+301215255,848191.0,Cc1cc(OC(C)(C)C(=O)N2C[C@H]3CCC[C@@H]2C3)cc(C)c1Cl,C1C[C@@H]2CN[C@H](C1)C2,Cc1cc(OC(C)(C)C(=O)O)cc(C)c1Cl,abf,,183.0,250.0,mg,274.0,1.0,g,,,,,,,
+303148016,38758125.0,Cc1ccc(-c2ccc(C(=O)N3CCC4(CC3)CC(C)N(C(=O)c3cn(-c5cccc(Br)c5)cn3)C4)nc2)c(C)c1,CC1CC2(CCN(C(=O)OC(C)(C)C)CC2)CN1,O=C(O)c1cn(-c2cccc(Br)c2)cn1,abf,abf,379.0,250.0,mg,108.0,100.0,mg,381.0,45493409.0,CC1CC2(CCNCC2)CN1C(=O)c1cn(-c2cccc(Br)c2)cn1,Cc1ccc(-c2ccc(C(=O)O)nc2)c(C)c1,165.0,1.0,g
+5856144,5850043.0,COC1CCC(N2CCN(c3cncc(C)n3)CC2)CC1,COC1CCC(=O)CC1,Cc1cncc(N2CCNCC2)n1,ra_k2,,15.0,100.0,mg,99.0,250.0,mg,,,,,,,
+6199790,37174003.0,CC1CC(C)CC(N2CCc3cc4c(cc3C2c2ccccc2)OCO4)C1,CC1CC(=O)CC(C)C1,c1ccc(C2NCCc3cc4c(cc32)OCO4)cc1,ra_k2,,8.0,250.0,mg,392.0,100.0,mg,,,,,,,
+303982924,847805.0,Cc1cc(OCc2ccc(C(=O)N[C@H]3CCC34CN(C(=O)Cc3ccc(S(N)(=O)=O)cc3)C4)cc2)cc(C)c1Cl,CC(C)(C)OC(=O)N1CC2(CC[C@@H]2N)C1,Cc1cc(OCc2ccc(C(=O)O)cc2)cc(C)c1Cl,abf,abf,617.0,100.0,mg,69.0,1.0,g,476.0,1495929.0,Cc1cc(OCc2ccc(C(=O)N[C@H]3CCC34CNC4)cc2)cc(C)c1Cl,NS(=O)(=O)c1ccc(CC(=O)O)cc1,66.0,250.0,mg
+301215255,848191.0,Cc1cc(OC(C)(C)C(=O)N2C[C@H]3CCC[C@@H]2C3)cc(C)c1Cl,C1C[C@@H]2CN[C@H](C1)C2,Cc1cc(OC(C)(C)C(=O)O)cc(C)c1Cl,abf,,183.0,250.0,mg,274.0,1.0,g,,,,,,,
+5856144,5850043.0,COC1CCC(N2CCN(c3cncc(C)n3)CC2)CC1,COC1CCC(=O)CC1,Cc1cncc(N2CCNCC2)n1,ra_k2,,15.0,100.0,mg,99.0,250.0,mg,,,,,,,
+313277536,50156296.0,Cc1ccc(Cl)c(Br)c1CNC(=O)c1cccc2ncc(O)cc12,Cc1ccc(Cl)c(Br)c1CN,O=C(O)c1cccc2ncc(O)cc12,abf,,10935.0,1.0,g,422.0,100.0,mg,,,,,,,

--- a/tests/test_similarity_search.py
+++ b/tests/test_similarity_search.py
@@ -1,0 +1,44 @@
+from typing import List
+
+import numpy as np
+import pandas as pd
+from pytest import fixture
+
+from synutils.similarity_search import (
+    chunk_similarity_search,
+    numba_tanimoto,
+    transform_to_fp,
+    transform_to_mol,
+)
+
+
+@fixture
+def clean_fp(clean_smiles_list: List[str]) -> np.ndarray:
+    return np.array(
+        [transform_to_fp(transform_to_mol(smiles)) for smiles in clean_smiles_list]
+    )
+
+
+def test_numba_tanimoto(clean_fp: np.ndarray):
+    assert all(
+        [
+            numba_tanimoto(clean_fp[ii], clean_fp)[ii] == 1.0
+            for ii in range(clean_fp.shape[0])
+        ]
+    )
+
+
+def test_chunk_similarity_search(
+    small_lib_df: pd.DataFrame, hit_candidates_df: pd.DataFrame
+):
+    max_sims, argmax_sims = chunk_similarity_search(
+        chunk=small_lib_df, candidates=hit_candidates_df
+    )
+    assert max_sims.shape[0] == hit_candidates_df.shape[0]
+    assert argmax_sims.shape[0] == hit_candidates_df.shape[0]
+    in_lib_smiles_idx = [
+        ii
+        for ii, smiles in enumerate(hit_candidates_df["smiles"])
+        if smiles in small_lib_df["product"].values
+    ]
+    assert all([max_sims[ii] == 1.0 for ii in in_lib_smiles_idx])


### PR DESCRIPTION
- Implement similarity search module.
- This module utilize numba to accelerate compute time and optimize the computation
- Here are some notes for numba.njit function
   -  Numba cannot work with rdkit mol objects
   - Putting the fingerprint information back to df and retrieving makes the dtype to be object, where numba cannot work with. Thus, we should save the fingerprint as np.array and use it for similarity search